### PR TITLE
Add document title for browsers/Bug: Favicon is missing

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -11,6 +11,7 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
             rel="stylesheet"
           />
+          <title>Marikone</title>
         </Head>
         <body style={{ height: "100%" }}>
           <Main />


### PR DESCRIPTION
## **Favicon** ##
_I cant reproduce BUG, I mean I do see favicon. Double checked and it is said that 'Next Js' which is used throughout project will automatically apply favicon which is placed in public folder._
>1.
>![image](https://user-images.githubusercontent.com/86976625/219962067-60966079-cad5-4c64-9e79-ebc2d7b2e00a.png)

>2.
>![image](https://user-images.githubusercontent.com/86976625/219962080-52132387-e5e8-4cf3-afaa-d610a0e517aa.png)

>3.
>![image](https://user-images.githubusercontent.com/86976625/219962205-ce48b5ad-430a-41fc-9f53-c92f79f76bcb.png)

## **Title** ##

_Title tag added_